### PR TITLE
fix missing db indexes

### DIFF
--- a/.opencode/skills/worktree-create/SKILL.md
+++ b/.opencode/skills/worktree-create/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: worktree-create
+description: Create and manage git worktrees with isolated environments using make commands. Use when the user wants to create, start, stop, check status of, or remove a parallel worktree environment for a branch.
+---
+
+# worktree-create
+
+Manage git worktrees with isolated Docker environments (Postgres, Redis) via `make parallel-*` targets.
+
+Each worktree gets a deterministic slot (1-8) with unique ports so multiple branches can run simultaneously.
+
+## Create a worktree
+
+```bash
+make parallel-create BRANCH=<branch-name>
+```
+
+This will:
+1. Create a git worktree for the branch via `workmux add`
+2. Copy `.env` from the repo root and override ports/container names for slot isolation
+3. Create `pg_data/` and `redis_data/` directories
+4. Write `.parallel-env.json` metadata in the worktree
+
+The worktree is placed under `../secrets-watch/worktrees/<branch-slug>`.
+
+## Start services (Docker)
+
+```bash
+make parallel-start BRANCH=<branch-name>
+```
+
+Brings up Postgres and Redis containers for the worktree and validates database connectivity.
+
+## Check status
+
+```bash
+make parallel-status
+```
+
+Or for a specific branch:
+
+```bash
+make parallel-status BRANCH=<branch-name>
+```
+
+Outputs a table with `branch slot app db redis state` for all managed worktrees.
+
+## Stop services
+
+```bash
+make parallel-stop BRANCH=<branch-name>
+```
+
+Stops Postgres and Redis containers without removing the worktree.
+
+## Remove a worktree
+
+```bash
+make parallel-remove BRANCH=<branch-name>
+```
+
+This will:
+1. Tear down Docker containers (`docker compose down --remove-orphans`)
+2. Close the tmux session via `workmux close`
+3. Remove `pg_data/`, `redis_data/`, `.parallel-env.json`
+4. Remove the git worktree entirely
+
+## Typical workflow
+
+```bash
+make parallel-create BRANCH=feature/new-thing
+make parallel-start BRANCH=feature/new-thing
+# ... work in the worktree ...
+make parallel-stop BRANCH=feature/new-thing
+make parallel-remove BRANCH=feature/new-thing
+```
+
+## Notes
+
+- A root `.env` file must exist before creating a worktree
+- The branch must not have a trailing slash
+- Slot collisions between branches are detected and reported
+- Up to 8 concurrent slots are supported

--- a/drizzle/0012_common_la_nuit.sql
+++ b/drizzle/0012_common_la_nuit.sql
@@ -1,0 +1,8 @@
+DROP INDEX "findings_check_id_fingerprint_idx";--> statement-breakpoint
+CREATE INDEX "findings_scan_id_idx" ON "findings" USING btree ("scan_id");--> statement-breakpoint
+CREATE INDEX "login_tokens_token_hash_idx" ON "login_tokens" USING btree ("token_hash");--> statement-breakpoint
+CREATE INDEX "login_tokens_email_idx" ON "login_tokens" USING btree ("email");--> statement-breakpoint
+CREATE INDEX "scans_domain_id_started_at_idx" ON "scans" USING btree ("domain_id","started_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "sessions_user_id_idx" ON "sessions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "user_domains_user_id_idx" ON "user_domains" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "user_domains_domain_user_id_idx" ON "user_domains" USING btree ("domain","user_id");

--- a/drizzle/0012_petite_tombstone.sql
+++ b/drizzle/0012_petite_tombstone.sql
@@ -5,4 +5,4 @@ CREATE INDEX "login_tokens_email_idx" ON "login_tokens" USING btree ("email");--
 CREATE INDEX "scans_domain_id_started_at_idx" ON "scans" USING btree ("domain_id","started_at" DESC NULLS LAST);--> statement-breakpoint
 CREATE INDEX "sessions_user_id_idx" ON "sessions" USING btree ("user_id");--> statement-breakpoint
 CREATE INDEX "user_domains_user_id_idx" ON "user_domains" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX "user_domains_domain_user_id_idx" ON "user_domains" USING btree ("domain","user_id");
+CREATE INDEX "user_domains_domain_idx" ON "user_domains" USING btree ("domain");

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,588 @@
+{
+	"id": "3d420ec3-8f2a-48f4-9ed6-ba3def25c55d",
+	"prevId": "da4d1fc6-7817-47f1-b42f-8c890802cfb4",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.domains": {
+			"name": "domains",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"hostname": {
+					"name": "hostname",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"domains_hostname_unique": {
+					"name": "domains_hostname_unique",
+					"nullsNotDistinct": false,
+					"columns": ["hostname"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.findings": {
+			"name": "findings",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"scan_id": {
+					"name": "scan_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"check_id": {
+					"name": "check_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "finding_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file": {
+					"name": "file",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snippet": {
+					"name": "snippet",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fingerprint": {
+					"name": "fingerprint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"findings_fingerprint_idx": {
+					"name": "findings_fingerprint_idx",
+					"columns": [
+						{
+							"expression": "fingerprint",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"findings_scan_id_idx": {
+					"name": "findings_scan_id_idx",
+					"columns": [
+						{
+							"expression": "scan_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"findings_scan_id_scans_id_fk": {
+					"name": "findings_scan_id_scans_id_fk",
+					"tableFrom": "findings",
+					"tableTo": "scans",
+					"columnsFrom": ["scan_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.login_tokens": {
+			"name": "login_tokens",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"used_at": {
+					"name": "used_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"login_tokens_token_hash_idx": {
+					"name": "login_tokens_token_hash_idx",
+					"columns": [
+						{
+							"expression": "token_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"login_tokens_email_idx": {
+					"name": "login_tokens_email_idx",
+					"columns": [
+						{
+							"expression": "email",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"login_tokens_email_users_email_fk": {
+					"name": "login_tokens_email_users_email_fk",
+					"tableFrom": "login_tokens",
+					"tableTo": "users",
+					"columnsFrom": ["email"],
+					"columnsTo": ["email"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.mock_emails": {
+			"name": "mock_emails",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"to": {
+					"name": "to",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"subject": {
+					"name": "subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"html": {
+					"name": "html",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.scans": {
+			"name": "scans",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"domain_id": {
+					"name": "domain_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "scan_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"discovery_metadata": {
+					"name": "discovery_metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"scans_domain_id_started_at_idx": {
+					"name": "scans_domain_id_started_at_idx",
+					"columns": [
+						{
+							"expression": "domain_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"scans_domain_id_domains_id_fk": {
+					"name": "scans_domain_id_domains_id_fk",
+					"tableFrom": "scans",
+					"tableTo": "domains",
+					"columnsFrom": ["domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sessions": {
+			"name": "sessions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"sessions_user_id_idx": {
+					"name": "sessions_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"sessions_user_id_users_id_fk": {
+					"name": "sessions_user_id_users_id_fk",
+					"tableFrom": "sessions",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_domains": {
+			"name": "user_domains",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"user_domains_user_id_idx": {
+					"name": "user_domains_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_domains_domain_user_id_idx": {
+					"name": "user_domains_domain_user_id_idx",
+					"columns": [
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_domains_user_id_users_id_fk": {
+					"name": "user_domains_user_id_users_id_fk",
+					"tableFrom": "user_domains",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stripe_customer_id": {
+					"name": "stripe_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_verified": {
+					"name": "is_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				},
+				"users_stripe_customer_id_unique": {
+					"name": "users_stripe_customer_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["stripe_customer_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.finding_type": {
+			"name": "finding_type",
+			"schema": "public",
+			"values": ["secret"]
+		},
+		"public.scan_status": {
+			"name": "scan_status",
+			"schema": "public",
+			"values": ["pending", "success", "failed"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,5 +1,5 @@
 {
-	"id": "3d420ec3-8f2a-48f4-9ed6-ba3def25c55d",
+	"id": "55eef912-56a2-4274-9c35-71f73dbb8a96",
 	"prevId": "da4d1fc6-7817-47f1-b42f-8c890802cfb4",
 	"version": "7",
 	"dialect": "postgresql",
@@ -468,17 +468,11 @@
 					"method": "btree",
 					"with": {}
 				},
-				"user_domains_domain_user_id_idx": {
-					"name": "user_domains_domain_user_id_idx",
+				"user_domains_domain_idx": {
+					"name": "user_domains_domain_idx",
 					"columns": [
 						{
 							"expression": "domain",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "user_id",
 							"isExpression": false,
 							"asc": true,
 							"nulls": "last"

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,97 +1,97 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1775781304893,
-      "tag": "0000_groovy_proteus",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1775825845801,
-      "tag": "0001_high_fixer",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1775826880323,
-      "tag": "0002_wet_adam_warlock",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1775840986789,
-      "tag": "0003_clammy_slapstick",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1775843729559,
-      "tag": "0004_tearful_madripoor",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1775870461712,
-      "tag": "0005_bitter_calypso",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1775870882410,
-      "tag": "0006_parallel_psynapse",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1776086063337,
-      "tag": "0007_happy_ezekiel_stane",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1776448177809,
-      "tag": "0008_needy_lady_mastermind",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1776470831461,
-      "tag": "0009_striped_marvel_boy",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1776471560223,
-      "tag": "0010_brown_northstar",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1776690587820,
-      "tag": "0011_mean_dust",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1776966252336,
-      "tag": "0012_common_la_nuit",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1775781304893,
+			"tag": "0000_groovy_proteus",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1775825845801,
+			"tag": "0001_high_fixer",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1775826880323,
+			"tag": "0002_wet_adam_warlock",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1775840986789,
+			"tag": "0003_clammy_slapstick",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1775843729559,
+			"tag": "0004_tearful_madripoor",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1775870461712,
+			"tag": "0005_bitter_calypso",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1775870882410,
+			"tag": "0006_parallel_psynapse",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1776086063337,
+			"tag": "0007_happy_ezekiel_stane",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1776448177809,
+			"tag": "0008_needy_lady_mastermind",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1776470831461,
+			"tag": "0009_striped_marvel_boy",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1776471560223,
+			"tag": "0010_brown_northstar",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1776690587820,
+			"tag": "0011_mean_dust",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1776966252336,
+			"tag": "0012_common_la_nuit",
+			"breakpoints": true
+		}
+	]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,90 +1,97 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1775781304893,
-			"tag": "0000_groovy_proteus",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1775825845801,
-			"tag": "0001_high_fixer",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1775826880323,
-			"tag": "0002_wet_adam_warlock",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1775840986789,
-			"tag": "0003_clammy_slapstick",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1775843729559,
-			"tag": "0004_tearful_madripoor",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1775870461712,
-			"tag": "0005_bitter_calypso",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1775870882410,
-			"tag": "0006_parallel_psynapse",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1776086063337,
-			"tag": "0007_happy_ezekiel_stane",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1776448177809,
-			"tag": "0008_needy_lady_mastermind",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1776470831461,
-			"tag": "0009_striped_marvel_boy",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1776471560223,
-			"tag": "0010_brown_northstar",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1776690587820,
-			"tag": "0011_mean_dust",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1775781304893,
+      "tag": "0000_groovy_proteus",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1775825845801,
+      "tag": "0001_high_fixer",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1775826880323,
+      "tag": "0002_wet_adam_warlock",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1775840986789,
+      "tag": "0003_clammy_slapstick",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1775843729559,
+      "tag": "0004_tearful_madripoor",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1775870461712,
+      "tag": "0005_bitter_calypso",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1775870882410,
+      "tag": "0006_parallel_psynapse",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1776086063337,
+      "tag": "0007_happy_ezekiel_stane",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776448177809,
+      "tag": "0008_needy_lady_mastermind",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776470831461,
+      "tag": "0009_striped_marvel_boy",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1776471560223,
+      "tag": "0010_brown_northstar",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1776690587820,
+      "tag": "0011_mean_dust",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1776966252336,
+      "tag": "0012_common_la_nuit",
+      "breakpoints": true
+    }
+  ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -89,8 +89,8 @@
 		{
 			"idx": 12,
 			"version": "7",
-			"when": 1776966252336,
-			"tag": "0012_common_la_nuit",
+			"when": 1776984449780,
+			"tag": "0012_petite_tombstone",
 			"breakpoints": true
 		}
 	]

--- a/src/server/db/indexes.integration.test.ts
+++ b/src/server/db/indexes.integration.test.ts
@@ -10,8 +10,7 @@ const expectedIndexes = [
 	{ name: 'login_tokens_token_hash_idx', table: 'login_tokens', defContains: '(token_hash)' },
 	{ name: 'login_tokens_email_idx', table: 'login_tokens', defContains: '(email)' },
 	{ name: 'user_domains_user_id_idx', table: 'user_domains', defContains: '(user_id)' },
-	{ name: 'user_domains_domain_user_id_idx', table: 'user_domains', defContains: '(domain' },
-	{ name: 'user_domains_domain_user_id_idx', table: 'user_domains', defContains: 'user_id)' },
+	{ name: 'user_domains_domain_idx', table: 'user_domains', defContains: '(domain)' },
 	{ name: 'sessions_user_id_idx', table: 'sessions', defContains: '(user_id)' },
 ];
 
@@ -19,9 +18,10 @@ describe('database indexes', () => {
 	for (const { name, table, defContains } of expectedIndexes) {
 		it(`should have index ${name} on ${table} containing ${defContains}`, async () => {
 			const result = await db.execute(
-				sql`SELECT indexdef FROM pg_indexes WHERE indexname = ${name}`,
+				sql`SELECT tablename, indexdef FROM pg_indexes WHERE indexname = ${name}`,
 			);
 			expect(result.rows.length).toBeGreaterThan(0);
+			expect(result.rows[0].tablename).toBe(table);
 			expect(result.rows[0].indexdef).toContain(defContains);
 		});
 	}

--- a/src/server/db/indexes.integration.test.ts
+++ b/src/server/db/indexes.integration.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { db } from './client.js';
+import { sql } from 'drizzle-orm';
+
+const expectedIndexes = [
+	{ name: 'findings_fingerprint_idx', table: 'findings', defContains: '(fingerprint)' },
+	{ name: 'findings_scan_id_idx', table: 'findings', defContains: '(scan_id)' },
+	{ name: 'scans_domain_id_started_at_idx', table: 'scans', defContains: '(domain_id' },
+	{ name: 'scans_domain_id_started_at_idx', table: 'scans', defContains: 'started_at DESC' },
+	{ name: 'login_tokens_token_hash_idx', table: 'login_tokens', defContains: '(token_hash)' },
+	{ name: 'login_tokens_email_idx', table: 'login_tokens', defContains: '(email)' },
+	{ name: 'user_domains_user_id_idx', table: 'user_domains', defContains: '(user_id)' },
+	{ name: 'user_domains_domain_user_id_idx', table: 'user_domains', defContains: '(domain' },
+	{ name: 'user_domains_domain_user_id_idx', table: 'user_domains', defContains: 'user_id)' },
+	{ name: 'sessions_user_id_idx', table: 'sessions', defContains: '(user_id)' },
+];
+
+describe('database indexes', () => {
+	for (const { name, table, defContains } of expectedIndexes) {
+		it(`should have index ${name} on ${table} containing ${defContains}`, async () => {
+			const result = await db.execute(
+				sql`SELECT indexdef FROM pg_indexes WHERE indexname = ${name}`,
+			);
+			expect(result.rows.length).toBeGreaterThan(0);
+			expect(result.rows[0].indexdef).toContain(defContains);
+		});
+	}
+
+	it('should not have findings_check_id_fingerprint_idx', async () => {
+		const result = await db.execute(
+			sql`SELECT indexdef FROM pg_indexes WHERE indexname = 'findings_check_id_fingerprint_idx'`,
+		);
+		expect(result.rows.length).toBe(0);
+	});
+});

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -10,30 +10,42 @@ export const domains = pgTable('domains', {
 	createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull(),
 });
 
-export const scans = pgTable('scans', {
-	id: uuid('id').primaryKey(),
-	domainId: uuid('domain_id')
-		.notNull()
-		// eslint-disable-next-line custom/no-raw-functions
-		.references(() => domains.id, { onDelete: 'cascade' }),
-	status: scanStatusEnum('status').notNull(),
-	startedAt: timestamp('started_at', { withTimezone: true, mode: 'date' }).notNull(),
-	finishedAt: timestamp('finished_at', { withTimezone: true, mode: 'date' }),
-	discoveryMetadata: jsonb('discovery_metadata').$type<{
-		discoveredSubdomains: string[];
-		stats: {
-			fromLinks: number;
-			fromSitemap: number;
-			totalConsidered: number;
-			totalAccepted: number;
-			truncated: boolean;
+export const scans = pgTable(
+	'scans',
+	{
+		id: uuid('id').primaryKey(),
+		domainId: uuid('domain_id')
+			.notNull()
+			// eslint-disable-next-line custom/no-raw-functions
+			.references(() => domains.id, { onDelete: 'cascade' }),
+		status: scanStatusEnum('status').notNull(),
+		startedAt: timestamp('started_at', { withTimezone: true, mode: 'date' }).notNull(),
+		finishedAt: timestamp('finished_at', { withTimezone: true, mode: 'date' }),
+		discoveryMetadata: jsonb('discovery_metadata').$type<{
+			discoveredSubdomains: string[];
+			stats: {
+				fromLinks: number;
+				fromSitemap: number;
+				totalConsidered: number;
+				totalAccepted: number;
+				truncated: boolean;
+			};
+			subdomainAssetCoverage: {
+				subdomain: string;
+				scannedAssetPaths: string[];
+			}[];
+		}>(),
+	},
+	// eslint-disable-next-line custom/no-raw-functions
+	(table) => {
+		return {
+			scansDomainIdStartedAtIdx: index('scans_domain_id_started_at_idx').on(
+				table.domainId,
+				table.startedAt.desc(),
+			),
 		};
-		subdomainAssetCoverage: {
-			subdomain: string;
-			scannedAssetPaths: string[];
-		}[];
-	}>(),
-});
+	},
+);
 
 export const findings = pgTable(
 	'findings',
@@ -54,10 +66,7 @@ export const findings = pgTable(
 	(table) => {
 		return {
 			findingsFingerprintIdx: index('findings_fingerprint_idx').on(table.fingerprint),
-			findingsCheckFingerprintIdx: index('findings_check_id_fingerprint_idx').on(
-				table.checkId,
-				table.fingerprint,
-			),
+			findingsScanIdIdx: index('findings_scan_id_idx').on(table.scanId),
 		};
 	},
 );
@@ -78,34 +87,66 @@ export const users = pgTable('users', {
 	createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull(),
 });
 
-export const loginTokens = pgTable('login_tokens', {
-	id: uuid('id').primaryKey(),
-	email: text('email')
-		.notNull()
-		// eslint-disable-next-line custom/no-raw-functions
-		.references(() => users.email, { onDelete: 'cascade' }),
-	tokenHash: text('token_hash').notNull(),
-	expiresAt: timestamp('expires_at', { withTimezone: true, mode: 'date' }).notNull(),
-	usedAt: timestamp('used_at', { withTimezone: true, mode: 'date' }),
-	createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull(),
-});
+export const loginTokens = pgTable(
+	'login_tokens',
+	{
+		id: uuid('id').primaryKey(),
+		email: text('email')
+			.notNull()
+			// eslint-disable-next-line custom/no-raw-functions
+			.references(() => users.email, { onDelete: 'cascade' }),
+		tokenHash: text('token_hash').notNull(),
+		expiresAt: timestamp('expires_at', { withTimezone: true, mode: 'date' }).notNull(),
+		usedAt: timestamp('used_at', { withTimezone: true, mode: 'date' }),
+		createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull(),
+	},
+	// eslint-disable-next-line custom/no-raw-functions
+	(table) => {
+		return {
+			loginTokensTokenHashIdx: index('login_tokens_token_hash_idx').on(table.tokenHash),
+			loginTokensEmailIdx: index('login_tokens_email_idx').on(table.email),
+		};
+	},
+);
 
-export const userDomains = pgTable('user_domains', {
-	id: uuid('id').primaryKey().defaultRandom(),
-	userId: uuid('user_id')
-		.notNull()
-		// eslint-disable-next-line custom/no-raw-functions
-		.references(() => users.id, { onDelete: 'cascade' }),
-	domain: text('domain').notNull(),
-	createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull(),
-});
+export const userDomains = pgTable(
+	'user_domains',
+	{
+		id: uuid('id').primaryKey().defaultRandom(),
+		userId: uuid('user_id')
+			.notNull()
+			// eslint-disable-next-line custom/no-raw-functions
+			.references(() => users.id, { onDelete: 'cascade' }),
+		domain: text('domain').notNull(),
+		createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull(),
+	},
+	// eslint-disable-next-line custom/no-raw-functions
+	(table) => {
+		return {
+			userDomainsUserIdIdx: index('user_domains_user_id_idx').on(table.userId),
+			userDomainsDomainUserIdIdx: index('user_domains_domain_user_id_idx').on(
+				table.domain,
+				table.userId,
+			),
+		};
+	},
+);
 
-export const sessions = pgTable('sessions', {
-	id: uuid('id').primaryKey(),
-	userId: uuid('user_id')
-		.notNull()
-		// eslint-disable-next-line custom/no-raw-functions
-		.references(() => users.id, { onDelete: 'cascade' }),
-	expiresAt: timestamp('expires_at', { withTimezone: true, mode: 'date' }).notNull(),
-	createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull(),
-});
+export const sessions = pgTable(
+	'sessions',
+	{
+		id: uuid('id').primaryKey(),
+		userId: uuid('user_id')
+			.notNull()
+			// eslint-disable-next-line custom/no-raw-functions
+			.references(() => users.id, { onDelete: 'cascade' }),
+		expiresAt: timestamp('expires_at', { withTimezone: true, mode: 'date' }).notNull(),
+		createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull(),
+	},
+	// eslint-disable-next-line custom/no-raw-functions
+	(table) => {
+		return {
+			sessionsUserIdIdx: index('sessions_user_id_idx').on(table.userId),
+		};
+	},
+);

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -124,10 +124,7 @@ export const userDomains = pgTable(
 	(table) => {
 		return {
 			userDomainsUserIdIdx: index('user_domains_user_id_idx').on(table.userId),
-			userDomainsDomainUserIdIdx: index('user_domains_domain_user_id_idx').on(
-				table.domain,
-				table.userId,
-			),
+			userDomainsDomainIdx: index('user_domains_domain_idx').on(table.domain),
 		};
 	},
 );


### PR DESCRIPTION
## Summary

Adds the missing database indexes described in #10 and removes the suboptimal findings composite index.

## Changes

- Adds `findings_scan_id_idx` on `findings(scan_id)`.
- Adds `scans_domain_id_started_at_idx` on `scans(domain_id, started_at DESC)`.
- Adds `login_tokens_token_hash_idx` on `login_tokens(token_hash)`.
- Adds `login_tokens_email_idx` on `login_tokens(email)`.
- Adds `user_domains_user_id_idx` on `user_domains(user_id)`.
- Adds `user_domains_domain_idx` on `user_domains(domain)`.
- Adds `sessions_user_id_idx` on `sessions(user_id)`.
- Drops `findings_check_id_fingerprint_idx`.
- Updates the integration test to verify required indexes and absence of the dropped index.

## Validation

- `npm run db:migrate`
- `npm test`
- `npm run lint` (passes with existing warnings only)
- commit hook: lint, tests, and Prettier check passed